### PR TITLE
Support multiple enable/disable minor-modes at once

### DIFF
--- a/helm-mode-manager.el
+++ b/helm-mode-manager.el
@@ -53,7 +53,9 @@
   (helm
    :sources '((name . "Minor modes")
               (candidates . minor-mode-list)
-              (action . (lambda (mode) (funcall (intern mode))))
+              (action . (lambda (_candidate)
+                          (dolist (mode (helm-marked-candidates))
+                            (funcall (intern mode)))))
               (persistent-action . helm-mode-manager-describe-mode))))
 
 ;;;###autoload
@@ -68,7 +70,9 @@
     (helm
      :sources '((name . "Active minor modes")
                 (candidates . active-minor-modes)
-                (action . (lambda (mode) (funcall (intern mode) -1)))
+                (action . (lambda (_candidate)
+                            (dolist (mode (helm-marked-candidates))
+                              (funcall (intern mode) -1))))
                 (persistent-action . helm-mode-manager-describe-mode)))))
 
 (defun helm-mode-manager-list-major-modes ()


### PR DESCRIPTION
For example, `flyspell-mode` and  `view-mode` are enabled at once in following animation GIF. (Please see minor-mode list in mode-line.)

![multiple-select](https://cloud.githubusercontent.com/assets/554281/11357118/a7e6b194-92a7-11e5-9b6b-3d70001a1c36.gif)
